### PR TITLE
fix: ignore capacity drift on eventhub namespace

### DIFF
--- a/modules/eventhub/main.tf
+++ b/modules/eventhub/main.tf
@@ -198,6 +198,10 @@ resource "azurerm_eventhub_namespace" "new" {
   auto_inflate_enabled     = var.eventhub_enable_auto_inflate
   maximum_throughput_units = var.eventhub_enable_auto_inflate ? var.eventhub_max_throughput_units : null
   tags                     = local.common_tags
+
+  lifecycle {
+    ignore_changes = [capacity]
+  }
 }
 
 # Data source for existing Event Hub when using existing Event Hub.


### PR DESCRIPTION
## Summary

Ignores runtime `capacity` changes on `azurerm_eventhub_namespace.new` in the `eventhub` module to stop perpetual Terraform drift.

Follow-up to the same fix in [`terraform-azurerm-integration-modules#171`](https://github.com/upwindsecurity/terraform-azurerm-integration-modules/pull/171) (Centrica, UP-3949) — the `eventhub` module here carries the identical Event Hub code and the same latent bug.

## Problem

The namespace has **auto-inflate enabled**, so Azure raises `capacity` (throughput units) at runtime under load (e.g. `1` → `2`). Because `capacity` is not set in config, every `terraform plan` sees `1` vs the real `2` and tries to revert it — perpetual drift, and any `apply` scales the namespace back down.

## Fix

```hcl
lifecycle {
  ignore_changes = [capacity]
}
```

`maximum_throughput_units` stays Terraform-managed and still bounds the auto-inflate ceiling — this only stops the churn on the current value.

## Notes

- Only affects the created-namespace path (`use_existing_eventhub = false`).
- Additive, no data-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)